### PR TITLE
Python27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,4 +74,4 @@ before_script:
   - cd oq-engine
   - python -c'import platform; print(platform.platform()); import multiprocessing; print("#CPUs=%d" % multiprocessing.cpu_count())'
   - celery worker --purge -Ofair --config openquake.engine.celeryconfig &
-  - python utils/celery-status
+  - sleep 10 && python utils/celery-status

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ cache:
   - wheels27
   - wheels35
 
-env:
-  - OQ_DISTRIBUTE=celery
-
 jobs:
   include:
   - stage: tests
@@ -29,7 +26,7 @@ jobs:
         - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.risklib
         - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.commands
-  - stage: tests
+  - stage: demos
     env: DEMOS
     script:
         - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
 jobs:
   include:
   - stage: tests
+    python:
+     - "2.7"
+     - "3.5"
     script:
         - nosetests --with-doctest -xvs -a'!slow' openquake.engine
         - nosetests --with-doctest -xvs -a'!slow' openquake.server
@@ -29,6 +32,9 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
   - stage: demos
+    python:
+     - "2.7"
+     - "3.5"
     script:
         - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
         - bin/check_demos

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,20 @@ cache:
   - wheels27
   - wheels35
 
+env:
+  - OQ_DISTRIBUTE=celery
+
 jobs:
   include:
   - stage: tests
-    env: ENGINE
     script:
-        - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.engine
-        - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.server
-        - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.calculators
-        - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.risklib
-        - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
-        - OQ_DISTRIBUTE=celery nosetests --with-doctest -xvs -a'!slow' openquake.commands
+        - nosetests --with-doctest -xvs -a'!slow' openquake.engine
+        - nosetests --with-doctest -xvs -a'!slow' openquake.server
+        - nosetests --with-doctest -xvs -a'!slow' openquake.calculators
+        - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
+        - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
+        - nosetests --with-doctest -xvs -a'!slow' openquake.commands
   - stage: demos
-    env: DEMOS
     script:
         - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
         - bin/check_demos

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ jobs:
     env:
       - OQ_DISTRIBUTE=celery
       - PYTHON=2.7
-    python:
-     - "2.7"
+    python: "2.7"
     script:
         - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
         - bin/check_demos
@@ -58,8 +57,7 @@ jobs:
     env:
       - OQ_DISTRIBUTE=celery
       - PYTHON=3.5
-    python:
-     - "3.5"
+    python: "3.5"
     script:
         - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
         - bin/check_demos

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   include:
-  - stage: python2.7 tests
+  - stage: python2.7
     python: "2.7"
     script:
         - nosetests --with-doctest -xvs -a'!slow' openquake.engine
@@ -30,7 +30,13 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
-  - stage: python3.5 tests
+  - stage: python2.7
+    python:
+     - "2.7"
+    script:
+        - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
+        - bin/check_demos
+  - stage: python3.5
     python: "3.5"
     script:
         - nosetests --with-doctest -xvs -a'!slow' openquake.engine
@@ -39,13 +45,7 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
-  - stage: python2.7 demos
-    python:
-     - "2.7"
-    script:
-        - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
-        - bin/check_demos
-  - stage: python3.5 demos
+  - stage: python3.5
     python:
      - "3.5"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ env:
 
 jobs:
   include:
-  - stage: python2.7
+  - stage: tests
+    env:
+      - OQ_DISTRIBUTE=celery
+      - PYTHON=2.7
     python: "2.7"
     script:
         - nosetests --with-doctest -xvs -a'!slow' openquake.engine
@@ -30,13 +33,10 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
-  - stage: python2.7
-    python:
-     - "2.7"
-    script:
-        - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
-        - bin/check_demos
-  - stage: python3.5
+  - stage: tests
+    env:
+      - OQ_DISTRIBUTE=celery
+      - PYTHON=3.5
     python: "3.5"
     script:
         - nosetests --with-doctest -xvs -a'!slow' openquake.engine
@@ -45,7 +45,19 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
-  - stage: python3.5
+  - stage: demo
+    env:
+      - OQ_DISTRIBUTE=celery
+      - PYTHON=2.7
+    python:
+     - "2.7"
+    script:
+        - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
+        - bin/check_demos
+  - stage: demo
+    env:
+      - OQ_DISTRIBUTE=celery
+      - PYTHON=3.5
     python:
      - "3.5"
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,24 +27,14 @@ jobs:
       - PYTHON=2.7
     python: "2.7"
     script:
-        - nosetests --with-doctest -xvs -a'!slow' openquake.engine
-        - nosetests --with-doctest -xvs -a'!slow' openquake.server
-        - nosetests --with-doctest -xvs -a'!slow' openquake.calculators
-        - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
-        - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
-        - nosetests --with-doctest -xvs -a'!slow' openquake.commands
+        - nosetests --with-doctest -xvs openquake
   - stage: tests
     env:
       - OQ_DISTRIBUTE=celery
       - PYTHON=3.5
     python: "3.5"
     script:
-        - nosetests --with-doctest -xvs -a'!slow' openquake.engine
-        - nosetests --with-doctest -xvs -a'!slow' openquake.server
-        - nosetests --with-doctest -xvs -a'!slow' openquake.calculators
-        - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
-        - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
-        - nosetests --with-doctest -xvs -a'!slow' openquake.commands
+        - nosetests --with-doctest -xvs openquake
   - stage: demo
     env:
       - OQ_DISTRIBUTE=celery

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 language: python
 
 python:
+ - "2.7"
  - "3.5"
 
 services:
@@ -11,7 +12,8 @@ services:
 cache:
   pip: true
   directories:
-  - wheels
+  - wheels27
+  - wheels35
 
 env:
   - OQ_DISTRIBUTE=celery
@@ -41,8 +43,8 @@ install:
   # the wheels first, put the folder in cache and then install the wheels from there.
   # A second run of 'pip download' will download only the missing wheels. 
   - if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${BRANCH})" == "" ]; then BRANCH='master'; fi; git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-engine.git && echo "Running on oq-engine/${BRANCH}"
-  - pip -q download -r oq-engine/requirements-py35-linux64.txt -d wheels
-  - pip -q install wheels/*
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip -q download -r oq-engine/requirements-py27-linux64.txt -d wheels27 && pip -q install wheels27/*; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip -q download -r oq-engine/requirements-py35-linux64.txt -d wheels35 && pip -q install wheels35/*; fi
   - pip -q install -e oq-engine
   # Setup RabbitMQ user and hosts
   - sudo rabbitmqctl add_user openquake openquake

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ sudo: required
 
 language: python
 
-python:
- - "2.7"
- - "3.5"
-
 services:
  - rabbitmq
 
@@ -20,10 +16,8 @@ env:
 
 jobs:
   include:
-  - stage: tests
-    python:
-     - "2.7"
-     - "3.5"
+  - stage: python2.7 tests
+    python: "2.7"
     script:
         - nosetests --with-doctest -xvs -a'!slow' openquake.engine
         - nosetests --with-doctest -xvs -a'!slow' openquake.server
@@ -31,9 +25,23 @@ jobs:
         - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
         - nosetests --with-doctest -xvs -a'!slow' openquake.commands
-  - stage: demos
+  - stage: python3.5 tests
+    python: "3.5"
+    script:
+        - nosetests --with-doctest -xvs -a'!slow' openquake.engine
+        - nosetests --with-doctest -xvs -a'!slow' openquake.server
+        - nosetests --with-doctest -xvs -a'!slow' openquake.calculators
+        - nosetests --with-doctest -xvs -a'!slow' openquake.risklib
+        - nosetests --with-doctest -xvs -a'!slow' openquake.commonlib
+        - nosetests --with-doctest -xvs -a'!slow' openquake.commands
+  - stage: python2.7 demos
     python:
      - "2.7"
+    script:
+        - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos
+        - bin/check_demos
+  - stage: python3.5 demos
+    python:
      - "3.5"
     script:
         - time bin/run-demos.sh $TRAVIS_BUILD_DIR/oq-engine/demos

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # oq-engine-celery
-Run OpenQuake Engine tests with Celery
+Run OpenQuake Engine tests with Celery [![Build Status](https://travis-ci.org/gem/oq-engine-celery.svg?branch=master)](https://travis-ci.org/gem/oq-engine-celery)


### PR DESCRIPTION
Tests and demos are now run with both Python 2.7 and Python 3.5. First tests are run in parallel and then the demos.