### PR TITLE
Removed tests with celery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,6 @@ env:
 
 jobs:
   include:
-  - stage: tests
-    env:
-      - OQ_DISTRIBUTE=celery
-      - PYTHON=2.7
-    python: "2.7"
-    script:
-        - nosetests --with-doctest -xvs openquake
-  - stage: tests
-    env:
-      - OQ_DISTRIBUTE=celery
-      - PYTHON=3.5
-    python: "3.5"
-    script:
-        - nosetests --with-doctest -xvs openquake
   - stage: demo
     env:
       - OQ_DISTRIBUTE=celery


### PR DESCRIPTION
I propose we run only the demos with celery, both with Python 2.7 and Python 3.5. The tests with celery hang for mysterious reasons on Travis. But the important thing is that the demos run.